### PR TITLE
feat: Add Slide component

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,12 +34,16 @@
     "@radix-ui/react-polymorphic": "^0.0.13",
     "clsx": "^1.1.1",
     "deepmerge": "^4.2.2",
-    "react-focus-on": "^3.5.2"
+    "react-focus-on": "^3.5.2",
+    "react-transition-group": "^4.4.2"
   },
   "peerDependencies": {
     "@vanilla-extract/css": "^1.2.1",
     "@vanilla-extract/sprinkles": "^1.0.0",
-    "react-dom": "^16.8 || ^17.0.0",
-    "react": "^16.8 || ^17.0"
+    "react": "^16.8 || ^17.0",
+    "react-dom": "^16.8 || ^17.0.0"
+  },
+  "devDependencies": {
+    "@types/react-transition-group": "^4.4.2"
   }
 }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@polaris/tokens": "*",
     "@radix-ui/react-polymorphic": "^0.0.13",
+    "@vanilla-extract/dynamic": "^2.0.0",
     "clsx": "^1.1.1",
     "deepmerge": "^4.2.2",
     "react-focus-on": "^3.5.2",

--- a/packages/components/src/components/Slide/Slide.css.ts
+++ b/packages/components/src/components/Slide/Slide.css.ts
@@ -1,0 +1,55 @@
+import {styleVariants} from '@vanilla-extract/css';
+
+import type {TransitionStyleVariants} from '../../utilities/motion';
+
+export type Direction = 'top' | 'right' | 'bottom' | 'left';
+
+export const DURATION = 500;
+
+const directionTransforms: [Direction, string][] = [
+  ['top', 'translate(0px, -200px)'],
+  ['right', 'translate(200px, 0px)'],
+  ['bottom', 'translate(0px, 200px)'],
+  ['left', 'translate(-200px, 0px)'],
+];
+
+export const directions: {
+  [K in Direction]?: ReturnType<typeof styleVariants>;
+} = {};
+
+const transition = `opacity ${DURATION}ms ease-in-out, transform ${DURATION}ms ease-in-out`;
+
+directionTransforms.forEach((config) => {
+  const [direction, transform] = config;
+
+  directions[direction] = styleVariants<TransitionStyleVariants>({
+    entering: {
+      opacity: 0,
+      transform,
+      transition,
+    },
+
+    entered: {
+      opacity: 1,
+      transform: 'translate(0px, 0px)',
+      transition,
+    },
+
+    exiting: {
+      opacity: 1,
+      transform: 'translate(0px, 0px)',
+      transition,
+    },
+
+    exited: {
+      opacity: 0,
+      transform,
+      transition,
+    },
+
+    unmounted: {
+      opacity: 0,
+      transform,
+    },
+  });
+});

--- a/packages/components/src/components/Slide/Slide.css.ts
+++ b/packages/components/src/components/Slide/Slide.css.ts
@@ -2,43 +2,60 @@ import {createVar, styleVariants} from '@vanilla-extract/css';
 
 import type {TransitionStyleVariants} from '../../utilities/motion';
 
-export const slideDurationVar = createVar();
+export const slideDurationAppearVar = createVar();
+export const slideDurationEnterVar = createVar();
+export const slideDurationExitVar = createVar();
 export const slideEasingVar = createVar();
-export const slideDirectionVar = createVar();
+export const slideDirectionStartVar = createVar();
 export const slideDistanceVar = createVar();
 
-const transition = `
-  opacity ${slideDurationVar} ${slideEasingVar},
-  transform ${slideDurationVar} ${slideEasingVar}
+const getTransition = (duration: ReturnType<typeof createVar>) => `
+  opacity ${duration} ${slideEasingVar},
+  transform ${duration} ${slideEasingVar}
 `;
 
 export const transitions = styleVariants<TransitionStyleVariants>({
-  entering: {
+  initial: {
     opacity: 0,
-    transform: slideDirectionVar,
-    transition,
+    transform: slideDirectionStartVar,
   },
-
-  entered: {
+  appear: {
+    opacity: 0,
+    transform: slideDirectionStartVar,
+  },
+  appearActive: {
     opacity: 1,
     transform: 'translate(0px, 0px)',
-    transition,
+    transition: getTransition(slideDurationAppearVar),
   },
-
-  exiting: {
+  appearDone: {
     opacity: 1,
     transform: 'translate(0px, 0px)',
-    transition,
   },
-
-  exited: {
+  enter: {
     opacity: 0,
-    transform: slideDirectionVar,
-    transition,
+    transform: slideDirectionStartVar,
   },
-
-  unmounted: {
+  enterActive: {
+    opacity: 1,
+    transform: 'translate(0px, 0px)',
+    transition: getTransition(slideDurationEnterVar),
+  },
+  enterDone: {
+    opacity: 1,
+    transform: 'translate(0px, 0px)',
+  },
+  exit: {
+    opacity: 1,
+    transform: 'translate(0px, 0px)',
+  },
+  exitActive: {
     opacity: 0,
-    transform: slideDirectionVar,
+    transform: slideDirectionStartVar,
+    transition: getTransition(slideDurationExitVar),
+  },
+  exitDone: {
+    opacity: 0,
+    transform: slideDirectionStartVar,
   },
 });

--- a/packages/components/src/components/Slide/Slide.css.ts
+++ b/packages/components/src/components/Slide/Slide.css.ts
@@ -1,16 +1,21 @@
-import {styleVariants} from '@vanilla-extract/css';
+import {createVar, styleVariants} from '@vanilla-extract/css';
 
 import type {TransitionStyleVariants} from '../../utilities/motion';
 
+export const slideDurationVar = createVar();
+export const slideEasingVar = createVar();
+export const slideDirectionVar = createVar();
+export const slideDistanceVar = createVar();
+
 const transition = `
-  opacity var(--slide-duration) var(--slide-easing),
-  transform var(--slide-duration) var(--slide-easing)
+  opacity ${slideDurationVar} ${slideEasingVar},
+  transform ${slideDurationVar} ${slideEasingVar}
 `;
 
 export const transitions = styleVariants<TransitionStyleVariants>({
   entering: {
     opacity: 0,
-    transform: 'var(--slide-direction)',
+    transform: slideDirectionVar,
     transition,
   },
 
@@ -28,12 +33,12 @@ export const transitions = styleVariants<TransitionStyleVariants>({
 
   exited: {
     opacity: 0,
-    transform: 'var(--slide-direction)',
+    transform: slideDirectionVar,
     transition,
   },
 
   unmounted: {
     opacity: 0,
-    transform: 'var(--slide-direction)',
+    transform: slideDirectionVar,
   },
 });

--- a/packages/components/src/components/Slide/Slide.css.ts
+++ b/packages/components/src/components/Slide/Slide.css.ts
@@ -2,9 +2,10 @@ import {styleVariants} from '@vanilla-extract/css';
 
 import type {TransitionStyleVariants} from '../../utilities/motion';
 
-// eslint-disable-next-line no-warning-comments
-// TODO: Add `--slide-curve` custom property to enable custom or themed timing functions.
-const transition = `opacity var(--slide-duration) ease-in-out, transform var(--slide-duration) ease-in-out`;
+const transition = `
+  opacity var(--slide-duration) var(--slide-easing),
+  transform var(--slide-duration) var(--slide-easing)
+`;
 
 export const transitions = styleVariants<TransitionStyleVariants>({
   entering: {

--- a/packages/components/src/components/Slide/Slide.css.ts
+++ b/packages/components/src/components/Slide/Slide.css.ts
@@ -2,54 +2,37 @@ import {styleVariants} from '@vanilla-extract/css';
 
 import type {TransitionStyleVariants} from '../../utilities/motion';
 
-export type Direction = 'top' | 'right' | 'bottom' | 'left';
+// eslint-disable-next-line no-warning-comments
+// TODO: Add `--slide-curve` custom property to enable custom or themed timing functions.
+const transition = `opacity var(--slide-duration) ease-in-out, transform var(--slide-duration) ease-in-out`;
 
-export const DURATION = 500;
+export const transitions = styleVariants<TransitionStyleVariants>({
+  entering: {
+    opacity: 0,
+    transform: 'var(--slide-direction)',
+    transition,
+  },
 
-const directionTransforms: [Direction, string][] = [
-  ['top', 'translate(0px, -200px)'],
-  ['right', 'translate(200px, 0px)'],
-  ['bottom', 'translate(0px, 200px)'],
-  ['left', 'translate(-200px, 0px)'],
-];
+  entered: {
+    opacity: 1,
+    transform: 'translate(0px, 0px)',
+    transition,
+  },
 
-export const directions: {
-  [K in Direction]?: ReturnType<typeof styleVariants>;
-} = {};
+  exiting: {
+    opacity: 1,
+    transform: 'translate(0px, 0px)',
+    transition,
+  },
 
-const transition = `opacity ${DURATION}ms ease-in-out, transform ${DURATION}ms ease-in-out`;
+  exited: {
+    opacity: 0,
+    transform: 'var(--slide-direction)',
+    transition,
+  },
 
-directionTransforms.forEach((config) => {
-  const [direction, transform] = config;
-
-  directions[direction] = styleVariants<TransitionStyleVariants>({
-    entering: {
-      opacity: 0,
-      transform,
-      transition,
-    },
-
-    entered: {
-      opacity: 1,
-      transform: 'translate(0px, 0px)',
-      transition,
-    },
-
-    exiting: {
-      opacity: 1,
-      transform: 'translate(0px, 0px)',
-      transition,
-    },
-
-    exited: {
-      opacity: 0,
-      transform,
-      transition,
-    },
-
-    unmounted: {
-      opacity: 0,
-      transform,
-    },
-  });
+  unmounted: {
+    opacity: 0,
+    transform: 'var(--slide-direction)',
+  },
 });

--- a/packages/components/src/components/Slide/Slide.tsx
+++ b/packages/components/src/components/Slide/Slide.tsx
@@ -8,21 +8,26 @@ import * as styles from './Slide.css';
 
 type Direction = 'top' | 'right' | 'bottom' | 'left';
 
+type Distance = number | string;
+
 type Duration = number | keyof typeof defaultVars.motion.duration;
 
-type Distance = number | string;
+type MotionEasing = keyof typeof defaultVars.motion.easing;
+
+type Easing = string | MotionEasing;
 
 export interface SlideProps {
   in: boolean;
 
   /**
    * The content of the Modal (e.g. `<div />`).
-   * It should be only one element that accepts a `className` prop.
+   * It should be only one element that accepts a `className` and `ref` prop.
    */
   children: NonNullable<React.ReactElement>;
   direction?: Direction;
-  duration?: Duration;
   distance?: Distance;
+  duration?: Duration;
+  easing?: Easing;
 }
 
 export const Slide = (props: SlideProps) => {
@@ -30,8 +35,9 @@ export const Slide = (props: SlideProps) => {
     in: inProp,
     children,
     direction = 'bottom',
-    duration = 1000,
+    duration = 300,
     distance = 200,
+    easing = 'easeInOut',
   } = props;
 
   const ref = React.useRef<null | HTMLElement>(null);
@@ -50,9 +56,10 @@ export const Slide = (props: SlideProps) => {
           ref,
           className: clsx(styles.transitions[status], children.props.className),
           style: {
-            '--slide-duration': getSlideDuration(duration),
-            '--slide-distance': getSlideDistance(distance),
             '--slide-direction': getSlideDirection(direction),
+            '--slide-distance': getSlideDistance(distance),
+            '--slide-duration': getSlideDuration(duration),
+            '--slide-easing': getSlideEasing(easing),
             ...children.props.style,
           },
         })
@@ -89,14 +96,24 @@ function getSlideDirection(direction: Direction) {
   return `translate(${translate.x}, ${translate.y})`;
 }
 
+function getSlideDistance(distance: Distance) {
+  return typeof distance === 'number' ? `${distance}px` : distance;
+}
+
 function getSlideDuration(duration: Duration) {
   return typeof duration === 'number'
     ? `${duration}ms`
     : defaultVars.motion.duration[duration];
 }
 
-function getSlideDistance(distance: Distance) {
-  return typeof distance === 'number' ? `${distance}px` : distance;
+const EASING_KEYS = Object.keys(defaultVars.motion.easing);
+
+function isEasingKey(easing: Easing): easing is MotionEasing {
+  return EASING_KEYS.includes(easing);
+}
+
+function getSlideEasing(easing: Easing) {
+  return isEasingKey(easing) ? defaultVars.motion.easing[easing] : easing;
 }
 
 function getTransitionDuration(element: HTMLElement) {

--- a/packages/components/src/components/Slide/Slide.tsx
+++ b/packages/components/src/components/Slide/Slide.tsx
@@ -4,6 +4,7 @@ import {CSSTransition} from 'react-transition-group';
 import clsx from 'clsx';
 
 import {defaultVars} from '../../theme/vars.css';
+import {useTheme} from '../../theme';
 
 import * as styles from './Slide.css';
 
@@ -11,7 +12,17 @@ type Direction = 'top' | 'right' | 'bottom' | 'left';
 
 type Distance = number | string;
 
-type Duration = number | keyof typeof defaultVars.motion.duration;
+type MotionDuration = keyof typeof defaultVars.motion.duration;
+
+type Timeout = number | MotionDuration;
+
+type Duration =
+  | Timeout
+  | {
+      appear?: Timeout;
+      enter: Timeout;
+      exit: Timeout;
+    };
 
 type MotionEasing = keyof typeof defaultVars.motion.easing;
 
@@ -36,37 +47,58 @@ export const Slide = (props: SlideProps) => {
     in: inProp,
     children,
     direction = 'bottom',
-    duration = 400,
+    duration = 'default',
     distance = 200,
     easing = 'easeInOut',
   } = props;
 
   const ref = React.useRef<null | HTMLElement>(null);
-  const [transitionDuration, setTransitionDuration] = React.useState(0);
+  const [timeouts, setTimeouts] = React.useState({
+    appear: 0,
+    enter: 0,
+    exit: 0,
+  });
+
+  const {themeClass} = useTheme();
 
   React.useEffect(() => {
     if (ref.current) {
-      setTransitionDuration(getTransitionDuration(ref.current));
+      setTimeouts(getTimeouts(themeClass, ref.current));
     }
-  }, [duration]);
+  }, [duration, themeClass]);
 
   return (
-    <CSSTransition in={inProp} timeout={transitionDuration}>
-      {(status) =>
-        React.cloneElement(React.Children.only(children), {
-          ref,
-          className: clsx(styles.transitions[status], children.props.className),
-          style: {
-            ...assignInlineVars({
-              [styles.slideDirectionVar]: getSlideDirection(direction),
-              [styles.slideDistanceVar]: getSlideDistance(distance),
-              [styles.slideDurationVar]: getSlideDuration(duration),
-              [styles.slideEasingVar]: getSlideEasing(easing),
-            }),
-            ...children.props.style,
-          },
-        })
-      }
+    <CSSTransition
+      appear
+      enter
+      exit
+      in={inProp}
+      timeout={timeouts}
+      classNames={{
+        appear: styles.transitions.appear,
+        appearActive: styles.transitions.appearActive,
+        appearDone: styles.transitions.appearDone,
+        enter: styles.transitions.enter,
+        enterActive: styles.transitions.enterActive,
+        enterDone: styles.transitions.enterDone,
+        exit: styles.transitions.exit,
+        exitActive: styles.transitions.exitActive,
+        exitDone: styles.transitions.exitDone,
+      }}
+    >
+      {React.cloneElement(React.Children.only(children), {
+        ref,
+        className: clsx(styles.transitions.initial, children.props.className),
+        style: {
+          ...assignInlineVars({
+            ...getSlideDuration(duration),
+            [styles.slideDirectionStartVar]: getSlideDirection(direction),
+            [styles.slideDistanceVar]: getSlideDistance(distance),
+            [styles.slideEasingVar]: getSlideEasing(easing),
+          }),
+          ...children.props.style,
+        },
+      })}
     </CSSTransition>
   );
 };
@@ -93,42 +125,162 @@ const directionOrigins: {[D in Direction]: {x: string; y: string}} = {
   },
 };
 
+/**
+ * Retrieves the starting translate position for a given direction configuration.
+ */
 function getSlideDirection(direction: Direction) {
   const translate = directionOrigins[direction];
 
   return `translate(${translate.x}, ${translate.y})`;
 }
 
+/**
+ * Retrieves the slide distance for a given distance configuration.
+ */
 function getSlideDistance(distance: Distance) {
   return typeof distance === 'number' ? `${distance}px` : distance;
 }
 
-function getSlideDuration(duration: Duration) {
-  return typeof duration === 'number'
-    ? `${duration}ms`
-    : defaultVars.motion.duration[duration];
-}
-
 const EASING_KEYS = Object.keys(defaultVars.motion.easing);
 
+/**
+ * Type guard to determine if the provided easing is a theme value and narrow
+ * the `string` to a literal `theme.motion.easing` key.
+ */
 function isEasingKey(easing: Easing): easing is MotionEasing {
   return EASING_KEYS.includes(easing);
 }
 
+/**
+ * Retrieves the transition timing function for a given easing configuration.
+ * @return Either a string representing a literal timing function or
+ * a `theme.motion.easing` value (CSS variable).
+ */
 function getSlideEasing(easing: Easing) {
   return isEasingKey(easing) ? defaultVars.motion.easing[easing] : easing;
 }
 
-function getTransitionDuration(element: HTMLElement) {
-  const styles = window.getComputedStyle(element);
+const DURATION_KEYS = Object.keys(defaultVars.motion.duration);
 
-  /**
-   * The computed `transition-duration` styles are represented as a common
-   * separated list where each value is the same in the context of the Slide animation
-   * component. Therefore, we simply split the value and use the first element.
-   */
-  const transitionDuration = styles.transitionDuration.split(', ')[0];
+/**
+ * Type guard to determine if the provided duration is a theme value and narrow
+ * the `string` to a literal `theme.motion.duration` key.
+ */
+function isDurationKey(duration: Duration): duration is MotionDuration {
+  return typeof duration === 'string' && DURATION_KEYS.includes(duration);
+}
 
-  // Convert transition-duration to a number represented in milliseconds
-  return parseFloat(transitionDuration) * 1000;
+/**
+ * Retrieves the slide duration for a given duration configuration.
+ */
+function getSlideDuration(duration: Duration) {
+  if (typeof duration === 'number' || isDurationKey(duration)) {
+    const timeout = getTimeout(duration);
+
+    return {
+      [styles.slideDurationAppearVar]: timeout,
+      [styles.slideDurationEnterVar]: timeout,
+      [styles.slideDurationExitVar]: timeout,
+    };
+  } else {
+    const enterTimeout = getTimeout(duration.enter);
+
+    return {
+      [styles.slideDurationAppearVar]: duration.appear
+        ? getTimeout(duration.appear)
+        : enterTimeout,
+      [styles.slideDurationEnterVar]: enterTimeout,
+      [styles.slideDurationExitVar]: getTimeout(duration.exit),
+    };
+  }
+}
+
+/**
+ * Retrieves the timeout for a given duration configuration.
+ * @return Either a string representing the timeout in milliseconds or
+ * a `theme.motion.duration` value (CSS variable).
+ */
+function getTimeout(timeout: Timeout) {
+  if (typeof timeout === 'number') {
+    return `${timeout}ms`;
+  } else {
+    return defaultVars.motion.duration[timeout];
+  }
+}
+
+/**
+ * Checks if a string is a CSS variable.
+ */
+function isVar(variable: string) {
+  return /^var\(.*\)$/.test(variable);
+}
+
+/**
+ * Extracts the custom property name from a CSS variable string.
+ */
+function getVarName(variable: string) {
+  const matches = variable.match(/^var\((.*)\)$/);
+
+  return matches ? matches[1] : variable;
+}
+
+/**
+ * Parses a transition-durations string to a number represented in milliseconds.
+ */
+function parseMilliseconds(timeout: string) {
+  // If `timeout` is already in milliseconds -> parse `timeout` as an integer.
+  // Otherwise `timeout` is in seconds -> parse the timeout as a float and convert to milliseconds.
+  return timeout.endsWith('ms')
+    ? parseInt(timeout, 10)
+    : parseFloat(timeout) * 1000;
+}
+
+/**
+ * Retrieves the computed value of a CSS property from a given element.
+ */
+function getPropertyValue(element: HTMLElement, property: string) {
+  return window.getComputedStyle(element).getPropertyValue(property);
+}
+
+/**
+ * Retrieves the transition timeouts for the inherited slide duration configuration.
+ * NOTE: This function would not be needed if we had access to the
+ * `theme.motion.duration` values directly (as they are only accessible as CSS Variables).
+ */
+function getTimeouts(themeClass: string, element: HTMLElement) {
+  // Initial timeouts derived from the children's computed styles.
+  const timeouts = {
+    appear: getPropertyValue(
+      element,
+      getVarName(styles.slideDurationAppearVar),
+    ),
+    enter: getPropertyValue(element, getVarName(styles.slideDurationEnterVar)),
+    exit: getPropertyValue(element, getVarName(styles.slideDurationExitVar)),
+  };
+
+  let themeElement: null | Element = null;
+
+  for (const t in timeouts) {
+    if (!(t in timeouts)) continue;
+
+    const timeout = t as keyof typeof timeouts;
+
+    // If the current timeout is a CSS variable (A.K.A. theme value),
+    // Retrieve the computed value from the theme element.
+    if (isVar(timeouts[timeout])) {
+      themeElement ||= document.getElementsByClassName(themeClass)[0];
+
+      // Update the current timeout with the computed theme value.
+      timeouts[timeout] =
+        themeElement instanceof HTMLElement
+          ? getPropertyValue(themeElement, getVarName(timeouts[timeout]))
+          : '0ms';
+    }
+  }
+
+  return {
+    appear: parseMilliseconds(timeouts.appear),
+    enter: parseMilliseconds(timeouts.enter),
+    exit: parseMilliseconds(timeouts.exit),
+  };
 }

--- a/packages/components/src/components/Slide/Slide.tsx
+++ b/packages/components/src/components/Slide/Slide.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import {CSSTransition} from 'react-transition-group';
+import clsx from 'clsx';
+
+import * as styles from './Slide.css';
+import type {Direction} from './Slide.css';
+
+export interface SlideProps {
+  in: boolean;
+
+  /**
+   * The content of the Modal (e.g. `<div />`).
+   * It should be only one element that accepts a `className` prop.
+   */
+  children: NonNullable<React.ReactElement>;
+  direction?: Direction;
+}
+
+export const Slide = (props: SlideProps) => {
+  const {in: inProp, children, direction = 'bottom'} = props;
+
+  return (
+    <CSSTransition in={inProp} timeout={styles.DURATION}>
+      {(status) =>
+        React.cloneElement(React.Children.only(children), {
+          className: clsx(
+            styles.directions[direction]?.[status],
+            children.props.className,
+          ),
+        })
+      }
+    </CSSTransition>
+  );
+};

--- a/packages/components/src/components/Slide/Slide.tsx
+++ b/packages/components/src/components/Slide/Slide.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {assignInlineVars} from '@vanilla-extract/dynamic';
 import {CSSTransition} from 'react-transition-group';
 import clsx from 'clsx';
 
@@ -35,7 +36,7 @@ export const Slide = (props: SlideProps) => {
     in: inProp,
     children,
     direction = 'bottom',
-    duration = 300,
+    duration = 400,
     distance = 200,
     easing = 'easeInOut',
   } = props;
@@ -56,10 +57,12 @@ export const Slide = (props: SlideProps) => {
           ref,
           className: clsx(styles.transitions[status], children.props.className),
           style: {
-            '--slide-direction': getSlideDirection(direction),
-            '--slide-distance': getSlideDistance(distance),
-            '--slide-duration': getSlideDuration(duration),
-            '--slide-easing': getSlideEasing(easing),
+            ...assignInlineVars({
+              [styles.slideDirectionVar]: getSlideDirection(direction),
+              [styles.slideDistanceVar]: getSlideDistance(distance),
+              [styles.slideDurationVar]: getSlideDuration(duration),
+              [styles.slideEasingVar]: getSlideEasing(easing),
+            }),
             ...children.props.style,
           },
         })
@@ -74,18 +77,18 @@ export const Slide = (props: SlideProps) => {
 const directionOrigins: {[D in Direction]: {x: string; y: string}} = {
   top: {
     x: '0px',
-    y: 'calc(var(--slide-distance) * -1)',
+    y: `calc(${styles.slideDistanceVar} * -1)`,
   },
   right: {
-    x: 'var(--slide-distance)',
+    x: styles.slideDistanceVar,
     y: '0px',
   },
   bottom: {
     x: '0px',
-    y: 'var(--slide-distance)',
+    y: styles.slideDistanceVar,
   },
   left: {
-    x: 'calc(var(--slide-distance) * -1)',
+    x: `calc(${styles.slideDistanceVar} * -1)`,
     y: '0px',
   },
 };

--- a/packages/components/src/components/Slide/Slide.tsx
+++ b/packages/components/src/components/Slide/Slide.tsx
@@ -2,8 +2,15 @@ import React from 'react';
 import {CSSTransition} from 'react-transition-group';
 import clsx from 'clsx';
 
+import {defaultVars} from '../../theme/vars.css';
+
 import * as styles from './Slide.css';
-import type {Direction} from './Slide.css';
+
+type Direction = 'top' | 'right' | 'bottom' | 'left';
+
+type Duration = number | keyof typeof defaultVars.motion.duration;
+
+type Distance = number | string;
 
 export interface SlideProps {
   in: boolean;
@@ -14,21 +21,94 @@ export interface SlideProps {
    */
   children: NonNullable<React.ReactElement>;
   direction?: Direction;
+  duration?: Duration;
+  distance?: Distance;
 }
 
 export const Slide = (props: SlideProps) => {
-  const {in: inProp, children, direction = 'bottom'} = props;
+  const {
+    in: inProp,
+    children,
+    direction = 'bottom',
+    duration = 1000,
+    distance = 200,
+  } = props;
+
+  const ref = React.useRef<null | HTMLElement>(null);
+  const [transitionDuration, setTransitionDuration] = React.useState(0);
+
+  React.useEffect(() => {
+    if (ref.current) {
+      setTransitionDuration(getTransitionDuration(ref.current));
+    }
+  }, [duration]);
 
   return (
-    <CSSTransition in={inProp} timeout={styles.DURATION}>
+    <CSSTransition in={inProp} timeout={transitionDuration}>
       {(status) =>
         React.cloneElement(React.Children.only(children), {
-          className: clsx(
-            styles.directions[direction]?.[status],
-            children.props.className,
-          ),
+          ref,
+          className: clsx(styles.transitions[status], children.props.className),
+          style: {
+            '--slide-duration': getSlideDuration(duration),
+            '--slide-distance': getSlideDistance(distance),
+            '--slide-direction': getSlideDirection(direction),
+            ...children.props.style,
+          },
         })
       }
     </CSSTransition>
   );
 };
+
+/**
+ * Represents the starting position for each Slide direction.
+ */
+const directionOrigins: {[D in Direction]: {x: string; y: string}} = {
+  top: {
+    x: '0px',
+    y: 'calc(var(--slide-distance) * -1)',
+  },
+  right: {
+    x: 'var(--slide-distance)',
+    y: '0px',
+  },
+  bottom: {
+    x: '0px',
+    y: 'var(--slide-distance)',
+  },
+  left: {
+    x: 'calc(var(--slide-distance) * -1)',
+    y: '0px',
+  },
+};
+
+function getSlideDirection(direction: Direction) {
+  const translate = directionOrigins[direction];
+
+  return `translate(${translate.x}, ${translate.y})`;
+}
+
+function getSlideDuration(duration: Duration) {
+  return typeof duration === 'number'
+    ? `${duration}ms`
+    : defaultVars.motion.duration[duration];
+}
+
+function getSlideDistance(distance: Distance) {
+  return typeof distance === 'number' ? `${distance}px` : distance;
+}
+
+function getTransitionDuration(element: HTMLElement) {
+  const styles = window.getComputedStyle(element);
+
+  /**
+   * The computed `transition-duration` styles are represented as a common
+   * separated list where each value is the same in the context of the Slide animation
+   * component. Therefore, we simply split the value and use the first element.
+   */
+  const transitionDuration = styles.transitionDuration.split(', ')[0];
+
+  // Convert transition-duration to a number represented in milliseconds
+  return parseFloat(transitionDuration) * 1000;
+}

--- a/packages/components/src/components/Slide/Slide.tsx
+++ b/packages/components/src/components/Slide/Slide.tsx
@@ -29,16 +29,32 @@ type MotionEasing = keyof typeof defaultVars.motion.easing;
 type Easing = string | MotionEasing;
 
 export interface SlideProps {
+  //
+  /**
+   * Triggers the enter or exit states.
+   */
   in: boolean;
 
   /**
-   * The content of the Modal (e.g. `<div />`).
+   * The content of the Slide (e.g. `<div />`).
    * It should be only one element that accepts a `className` and `ref` prop.
    */
   children: NonNullable<React.ReactElement>;
+
+  /** The direction the slide will animate in from. */
   direction?: Direction;
+
+  /** The distance the slide animation will translate. */
   distance?: Distance;
+
+  /**
+   * The duration for each transition state.
+   * Note: A single value will be used for all transition states and
+   * a configuration object can control each transition states independently.
+   */
   duration?: Duration;
+
+  /** The timing function used for all transition states. */
   easing?: Easing;
 }
 

--- a/packages/components/src/components/Slide/index.ts
+++ b/packages/components/src/components/Slide/index.ts
@@ -1,0 +1,2 @@
+export {Slide} from './Slide';
+export type {SlideProps} from './Slide';

--- a/packages/components/src/components/index.ts
+++ b/packages/components/src/components/index.ts
@@ -8,4 +8,5 @@ export * from './Grid';
 export * from './Inline';
 export * from './Link';
 export * from './Portal';
+export * from './Slide';
 export * from './Stack';

--- a/packages/components/src/theme/createTheme.ts
+++ b/packages/components/src/theme/createTheme.ts
@@ -32,6 +32,9 @@ type Theme = {
     placeholder2: string;
   };
   spacing: typeof tokens.spacing;
+  motion: {
+    duration: typeof tokens.duration;
+  };
 };
 
 type ThemeOptions = DeepPartial<Theme>;
@@ -44,6 +47,9 @@ export const defaultTheme: Theme = {
     placeholder2: '#BFCC94',
   },
   spacing: tokens.spacing,
+  motion: {
+    duration: tokens.duration,
+  },
 };
 
 interface NullableTokens {

--- a/packages/components/src/theme/createTheme.ts
+++ b/packages/components/src/theme/createTheme.ts
@@ -34,6 +34,7 @@ type Theme = {
   spacing: typeof tokens.spacing;
   motion: {
     duration: typeof tokens.duration;
+    easing: typeof tokens.easing;
   };
 };
 
@@ -49,6 +50,7 @@ export const defaultTheme: Theme = {
   spacing: tokens.spacing,
   motion: {
     duration: tokens.duration,
+    easing: tokens.easing,
   },
 };
 

--- a/packages/components/src/utilities/motion.ts
+++ b/packages/components/src/utilities/motion.ts
@@ -1,0 +1,26 @@
+import {StyleRule} from '@vanilla-extract/css';
+import {TransitionStatus} from 'react-transition-group';
+
+/**
+ * Recreation of the Vanilla Extract type used for validating the `styleVariants` API:
+ * https://github.com/seek-oss/vanilla-extract/blob/d101b43546ce4d94b1ef51cb3fe89ff7901a5947/packages/css/src/style.ts#L22
+ */
+type ComplexStyleRule = StyleRule | (StyleRule | ClassNames)[];
+type ClassNames = string | ClassNames[];
+
+/**
+ * Map of `react-transition-group` statuses to `vanilla-extract` style rules to
+ * be passed as a type argument to the `styleVariants` generic.
+ * @example
+ * import {styleVariants} from '@vanilla-extract/css'
+ * import type {TransitionStyleVariants} from './utilities/motion'
+ *
+ * const variant = styleVariants<TransitionStyleVariants>({
+ *   entering: {...},
+ *   entered: {...},
+ *   // etc...
+ * })
+ */
+export type TransitionStyleVariants = {
+  [K in TransitionStatus]: ComplexStyleRule;
+};

--- a/packages/components/src/utilities/motion.ts
+++ b/packages/components/src/utilities/motion.ts
@@ -1,5 +1,23 @@
+import React from 'react';
 import {StyleRule} from '@vanilla-extract/css';
-import {TransitionStatus} from 'react-transition-group';
+import {CSSTransition} from 'react-transition-group';
+
+/**
+ * Utility type to extract the `CSSTransitionClassNames` type from the
+ * CSSTransition `classNames` union.
+ */
+type ExtractClassNames<T> = T extends string
+  ? never
+  : T extends undefined
+  ? never
+  : T;
+
+/**
+ * Type for the CSSTransition `classNames` prop.
+ */
+type CSSTransitionClassNames = ExtractClassNames<
+  React.ComponentProps<typeof CSSTransition>['classNames']
+>;
 
 /**
  * Recreation of the Vanilla Extract type used for validating the `styleVariants` API:
@@ -9,18 +27,18 @@ type ComplexStyleRule = StyleRule | (StyleRule | ClassNames)[];
 type ClassNames = string | ClassNames[];
 
 /**
- * Map of `react-transition-group` statuses to `vanilla-extract` style rules to
+ * Map of `react-transition-group` `classNames` to `vanilla-extract` style rules to
  * be passed as a type argument to the `styleVariants` generic.
  * @example
  * import {styleVariants} from '@vanilla-extract/css'
  * import type {TransitionStyleVariants} from './utilities/motion'
  *
  * const variant = styleVariants<TransitionStyleVariants>({
- *   entering: {...},
- *   entered: {...},
+ *   enterActive: {...},
+ *   enterDone: {...},
  *   // etc...
  * })
  */
 export type TransitionStyleVariants = {
-  [K in TransitionStatus]: ComplexStyleRule;
+  [K in 'initial' | keyof CSSTransitionClassNames]: ComplexStyleRule;
 };

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,2 +1,3 @@
 export {breakpoints} from './breakpoints';
+export {duration} from './motion';
 export {spacing} from './spacing';

--- a/packages/tokens/src/index.ts
+++ b/packages/tokens/src/index.ts
@@ -1,3 +1,3 @@
 export {breakpoints} from './breakpoints';
-export {duration} from './motion';
+export {duration, easing} from './motion';
 export {spacing} from './spacing';

--- a/packages/tokens/src/motion.ts
+++ b/packages/tokens/src/motion.ts
@@ -1,10 +1,7 @@
 export const duration = {
-  immediateEnter: '0ms',
-  immediateExit: '0ms',
-  swiftEnter: '100ms',
-  swiftExit: '150ms',
-  defaultEnter: '200ms',
-  defaultExit: '200ms',
+  immediate: '0ms',
+  swift: '100ms',
+  default: '200ms',
 };
 
 export const easing = {

--- a/packages/tokens/src/motion.ts
+++ b/packages/tokens/src/motion.ts
@@ -6,3 +6,10 @@ export const duration = {
   defaultEnter: '200ms',
   defaultExit: '200ms',
 };
+
+export const easing = {
+  easeInOut: 'cubic-bezier(0.4, 0, 0.2, 1)',
+  easeOut: 'cubic-bezier(0.0, 0, 0.2, 1)',
+  easeIn: 'cubic-bezier(0.4, 0, 1, 1)',
+  sharp: 'cubic-bezier(0.4, 0, 0.6, 1)',
+};

--- a/packages/tokens/src/motion.ts
+++ b/packages/tokens/src/motion.ts
@@ -1,0 +1,8 @@
+export const duration = {
+  immediateEnter: '0ms',
+  immediateExit: '0ms',
+  swiftEnter: '100ms',
+  swiftExit: '150ms',
+  defaultEnter: '200ms',
+  defaultExit: '200ms',
+};

--- a/packages/tokens/src/motion.ts
+++ b/packages/tokens/src/motion.ts
@@ -1,7 +1,9 @@
 export const duration = {
   immediate: '0ms',
-  swift: '100ms',
-  default: '200ms',
+  swift: '150ms',
+  swiftExit: '100ms',
+  default: '250ms',
+  defaultExit: '200ms',
 };
 
 export const easing = {

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -1,12 +1,60 @@
+/* eslint-disable react/jsx-child-element-spacing */
 import React from 'react';
-import {Box, Flex, Inline, Stack, Link} from '@polaris/components';
+import {
+  Box,
+  Flex,
+  Inline,
+  Stack,
+  Link,
+  Slide,
+  SlideProps,
+} from '@polaris/components';
 import {Link as RouterLink} from 'react-router-dom';
 
 import {Layout} from '../components/Layout';
 
 const IndexPage = () => {
+  const [inProp, setIn] = React.useState(false);
+  const [direction, setDirection] =
+    React.useState<SlideProps['direction']>('bottom');
+
+  function toggleIn() {
+    setIn((prevIn) => !prevIn);
+  }
+
   return (
     <Layout>
+      <h2>Slide: {inProp.toString()}</h2>
+      <button type="button" onClick={toggleIn}>
+        Toggle Slide
+      </button>
+      <br />
+      {/* eslint-disable-next-line jsx-a11y/label-has-for */}
+      <label>
+        Slide Direction:
+        <select
+          value={direction}
+          onChange={(event) =>
+            setDirection(event.target.value as SlideProps['direction'])
+          }
+        >
+          <option value="top">Top</option>
+          <option value="right">Right</option>
+          <option value="bottom">Bottom</option>
+          <option value="left">Left</option>
+        </select>
+      </label>
+      <Slide in={inProp} direction={direction}>
+        <Box
+          style={{backgroundColor: 'silver'}}
+          height="16"
+          width="16"
+          marginY="4"
+        />
+      </Slide>
+
+      <Divider />
+
       <h2>Link</h2>
       <Link href="/about">Hyperlink</Link>
       <br />

--- a/website/pages/index.tsx
+++ b/website/pages/index.tsx
@@ -44,7 +44,11 @@ const IndexPage = () => {
           <option value="left">Left</option>
         </select>
       </label>
-      <Slide in={inProp} direction={direction}>
+      <Slide
+        in={inProp}
+        direction={direction}
+        duration={{enter: 2500, exit: 750}}
+      >
         <Box
           style={{backgroundColor: 'silver'}}
           height="16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.8.7":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.15.4.tgz#fd17d16bfdf878e6dd02d19753a39fa8a8d9c84a"
+  integrity sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz"
@@ -1617,6 +1624,13 @@
   integrity sha512-8d7nR/fNSqlTFGHti0R3F9WwIertOaaA1UEB8/jr5l5mDMOs4CidEgvvYMw4ivqrBK+vtVLxyTj2P+Pr/dtgzg==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+
+"@types/react-transition-group@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.2.tgz#38890fd9db68bf1f2252b99a942998dc7877c5b3"
+  integrity sha512-KibDWL6nshuOJ0fu8ll7QnV/LVTo3PzQ9aCPnRUYPfX7eZohHwLIdNHj7pftanREzHNP4/nJa8oeM73uSiavMQ==
+  dependencies:
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^17.0.0":
@@ -3782,6 +3796,14 @@ dom-accessibility-api@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.7.tgz#8c2aa6325968f2933160a0b7dbb380893ddf3e7d"
   integrity sha512-ml3lJIq9YjUfM9TUnEPvEYWFSwivwIGBPKpewX7tii7fwCazA8yCioGdqQcNsItPpfFvSJ3VIdMQPj60LJhcQA==
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dom-serializer@^1.0.1:
   version "1.3.2"
@@ -8158,6 +8180,16 @@ react-style-singleton@^2.1.0, react-style-singleton@^2.1.1:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^1.0.0"
+
+react-transition-group@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^17.0.0, react@^17.0.2:
   version "17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,6 +1806,13 @@
     deep-object-diff "^1.1.0"
     deepmerge "^4.2.2"
 
+"@vanilla-extract/dynamic@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@vanilla-extract/dynamic/-/dynamic-2.0.0.tgz#166f5b69db992f0567c637f767d9ef060f018eff"
+  integrity sha512-w24BI/NhxZ7KxKRTIkZVZA/V2BNgmZ9ocDTbqZ8+kLfEobejwS60aFkeBu/11upEc4PhmFE1v27v5M8zcaGA6Q==
+  dependencies:
+    "@vanilla-extract/private" "^1.0.0"
+
 "@vanilla-extract/integration@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@vanilla-extract/integration/-/integration-1.3.0.tgz#3d3119db30d8a45368c012d5785939cadc007cec"
@@ -1820,7 +1827,7 @@
     javascript-stringify "^2.0.1"
     lodash "^4.17.21"
 
-"@vanilla-extract/private@^1.0.1":
+"@vanilla-extract/private@^1.0.0", "@vanilla-extract/private@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@vanilla-extract/private/-/private-1.0.1.tgz#c9479cebea7e7fbb07a1fe5b5c988a8753ef04ed"
   integrity sha512-ABrFJGSmF7a1M+eDTsIeAErPhIeRyBY3ypyLQPc4bUVEK1mvF7F2gx4fTP81pm12bkS0GhjSJtM854lcPWhB+w==


### PR DESCRIPTION
### Short Description:

This PR is simply an exploration on exposing (wrapper) animation components using `vanilla-extract`:

- Added `react-transition-group` and `@types` dependencies to `@polaris/components`
- Added utility types to validate `react-transition-group`/`vanilla-extract` style variants
- Created the `Slide` component

Note: The integration between `react-transition-group` and `vanilla-extract` is quite seamless and I am satisfied with the pattern established in this PR.

~However, the lack of dynamic style support greatly reduces the flexibility of the `Slide` component. Ideally, we could expose additional props that provide more fine grain control (i.e. `duration`, `distance`, custom timing functions, etc.) but the constraint on build time styles eliminates this option. Unless of course we use inline styles (which I would prefer to avoid). The only other option I can think of is to add a limited range of values for `duration`, `distance`, etc... to the `theme` which we expose through the `Slide` component props interface and configurable at the `theme` level.~

Update:

After pairing with @samrose3 and @lgriffee, we determined that it is possible to enable dynamic behavior through a combination of css custom properties and inline styles: https://github.com/Shopify/polaris/pull/311/commits/76214d935046b33f837421401575ee11b56469cc

### Example

#### Demonstrates: The `Slide` component being triggered in multiple directions. NOTE: All static values.

https://user-images.githubusercontent.com/32409546/132747685-3d985c68-b6c2-4746-9f8d-52f538633ad1.mov

